### PR TITLE
[PTT-144] fix hash fragment for spid token in success call

### DIFF
--- a/src/app/pages/login-spid-success/login-spid-success.component.ts
+++ b/src/app/pages/login-spid-success/login-spid-success.component.ts
@@ -24,23 +24,26 @@ export class LoginSpidSuccessComponent implements OnInit {
 
   ngOnInit(): void {
     // eslint-disable-next-line sonarjs/cognitive-complexity
-    this.activatedRoute.queryParamMap.subscribe(params => {
-      const token = params.get('token');
-      if (token) {
-        this.tokenService.setToken(token);
-        this.authService.getFiscalCodeByToken(this.tokenService.getToken()).subscribe(resTIR => {
-          if (resTIR && resTIR.user.fiscal_number) {
-            this.tokenService.setFiscalCodeREFP(resTIR.user.fiscal_number);
-            this.enteService.checkPrivacyByRefP(this.tokenService.getFiscalCodeREFP()).subscribe(resBR1 => {
-              if (resBR1 && resBR1.result) {
-                this.privacyCallback();
-              } else {
-                // eslint-disable-next-line functional/immutable-data
-                this.canCreatePrivacy = true;
-              }
-            });
-          }
-        });
+    this.activatedRoute.fragment.subscribe((fragment: string | null) => {
+      if(fragment) {
+        const urlParams = new URLSearchParams(fragment);
+        const token = urlParams.get('token');
+        if (token) {
+          this.tokenService.setToken(token);
+          this.authService.getFiscalCodeByToken(this.tokenService.getToken()).subscribe(resTIR => {
+            if (resTIR && resTIR.user.fiscal_number) {
+              this.tokenService.setFiscalCodeREFP(resTIR.user.fiscal_number);
+              this.enteService.checkPrivacyByRefP(this.tokenService.getFiscalCodeREFP()).subscribe(resBR1 => {
+                if (resBR1 && resBR1.result) {
+                  this.privacyCallback();
+                } else {
+                  // eslint-disable-next-line functional/immutable-data
+                  this.canCreatePrivacy = true;
+                }
+              });
+            }
+          });
+        }
       }
     });
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR correct the problem of the success page that not retrieve the RefP information
#### List of Changes
-login-spid-success.component.ts
<!--- Describe your changes in detail -->
The token was read by query param, but it is passed by hash fragment
#### Motivation and Context
Fix the problem
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
-local test 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
